### PR TITLE
adding python libraries for access with Ansible

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -7,3 +7,6 @@
   with_items:
     - MariaDB-server
     - MariaDB-client
+    - MariaDB-common
+    - MySQL-python
+    

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -20,3 +20,5 @@
   with_items:
     - mariadb-server
     - mariadb-client
+    - mariadb-common
+    - python-mysqldb


### PR DESCRIPTION
When adding  python libraries to the install, Ansible can create users and databases for other roles.
