### PR TITLE
Install mysql python package when required.

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -7,3 +7,7 @@
   with_items:
     - MariaDB-server
     - MariaDB-client
+
+- name: Install MySQLdb Python package for secure installations.
+  yum: name=MySQL-python state=present
+  when: mysql_secure_installation and mysql_root_password is defined

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -20,3 +20,7 @@
   with_items:
     - mariadb-server
     - mariadb-client
+
+- name: Install MySQLdb Python package for secure installations.
+  apt: pkg=python-mysqldb state=present
+  when: mysql_secure_installation and mysql_root_password is defined


### PR DESCRIPTION
When installing MariaDB using the “secure-installation” task then the
mysql python package is required due to the `mysql_user` call. This
will make sure that, this package is available when needed.

PCextreme/ansible-role-mariadb#5
